### PR TITLE
Py libperf

### DIFF
--- a/tools/lib/perf/include/perf/py_perf.h
+++ b/tools/lib/perf/include/perf/py_perf.h
@@ -11,6 +11,30 @@ typedef struct {
 	struct perf_thread_map *ptr;
 } py_perf_thread_map;
 
+static void py_perf_thread_map_dealloc(py_perf_thread_map *thread_map)
+{
+	Py_DECREF(thread_map);
+	PyObject_Del((PyObject *)thread_map);
+}
+
+static PyTypeObject py_perf_thread_map_type = {
+	PyVarObject_HEAD_INIT(NULL, 0)
+	.tp_name = "libperf.py_perf_thread_map",
+	.tp_doc = "Perf thread map object",
+	.tp_basicsize = sizeof(py_perf_thread_map),
+	.tp_dealloc = (destructor)py_perf_thread_map_dealloc,
+	.tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
+};
+
+static void
+python_push_type(const char *name, PyObject *module, PyTypeObject *type)
+{
+	if (PyType_Ready(type) == -1)
+		printf("python_push_type: failed to ready %s", name);
+
+	Py_INCREF(type);
+}
+
 LIBPERF_API PyMODINIT_FUNC PyInit_libperf(void);
 
 #endif /* __LIBPERF_PY_PERF_H */

--- a/tools/lib/perf/py_perf.c
+++ b/tools/lib/perf/py_perf.c
@@ -15,8 +15,16 @@ static PyObject *program_perf_thread_map__new_dummy(PyObject *self, PyObject *ar
 	return Py_BuildValue("O", pythread_map);
 }
 
+static PyObject *program_libperf_init(PyObject *self, PyObject *args)
+{
+       /* TODO: We need to figure out how to pass a function from python to libperf_init() */
+       libperf_init(NULL);
+       return Py_None;
+}
+
 PyMethodDef libperf_methods[] = {
 	{"perf_thread_map__new_dummy", program_perf_thread_map__new_dummy, METH_VARARGS, "Create a dummy thread map function variable"},
+	{"libperf_init", program_libperf_init, METH_VARARGS, "libperf init"},
 	{NULL, NULL, 0, NULL}
 };
 

--- a/tools/lib/perf/py_perf.c
+++ b/tools/lib/perf/py_perf.c
@@ -1,21 +1,18 @@
 /* SPDX-License-Identifier: GPL-2.0 */
+#include "include/perf/py_perf.h"
 #include <stdlib.h>
 #include <perf/threadmap.h>
 #include <perf/py_perf.h>
+#include <errno.h>
+#include <internal/threadmap.h>
 
-static PyObject * program_perf_thread_map__new_dummy(PyObject *self, PyObject *args)
+static PyObject *program_perf_thread_map__new_dummy(PyObject *self, PyObject *args)
 {
-	py_perf_thread_map *pythread_map;
-	PyObject *obj;
-
-	pythread_map = calloc(sizeof(py_perf_thread_map), 1);
-	if (!pythread_map)
-		Py_RETURN_FALSE;
+	py_perf_thread_map *pythread_map = PyObject_New(py_perf_thread_map, &py_perf_thread_map_type);
 
 	pythread_map->ptr = perf_thread_map__new_dummy();
 
-	obj = Py_BuildValue("&O", pythread_map);
-	return obj;
+	return Py_BuildValue("O", pythread_map);
 }
 
 PyMethodDef libperf_methods[] = {
@@ -36,6 +33,8 @@ PyMODINIT_FUNC PyInit_libperf(void) {
 
 	if (!m)
 		return NULL;
+
+	python_push_type("py_perf_thread_map", m, &py_perf_thread_map_type);
 
 	return m;
 }


### PR DESCRIPTION
Fixed a segfault in perf_thread_map__new_dummy() and added partial support for libperf_init()

I'm able to call these functions from python:
```python
#!/usr/bin/python3

import sys
sys.path.append('/home/gautam/work/github_repos/linux_upstream/tools/lib/perf/')
from libperf import *

libperf_init(None)
threads = perf_thread_map__new_dummy()
assert(threads)
``` 